### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,6 @@
     <PackageVersion Include="MinVer" Version="6.0.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageVersion Include="Ramstack.Parsing" Version="1.0.0" />
+    <PackageVersion Include="Ramstack.Parsing" Version="1.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update the `Ramstack.Parsing` package to version `1.0.1`, which includes a fix for an issue in the `AdvSimd` logic.